### PR TITLE
preprocessor delete drop-nan-columns

### DIFF
--- a/autoinsight_frontend/templates/preprocess.html
+++ b/autoinsight_frontend/templates/preprocess.html
@@ -368,10 +368,10 @@
                         <div class="tab-pane fade" id="processor" role="tabpanel" aria-labelledby="processor-tab">
                             <button class="btn_m btn_border" type="button" onclick="$FRONTEND._p.autoConf()">Auto Configure</button>
                             <dl class="list_processor">
-                                <div class="item_dl type_inline">
-                                    <dt>                                  <!-- ============= processor Add Dataset Button ============= -->
-                                        <div class="wrap_check">        <!-- seems like there is no button except general page Check it...  -->
-                                            <input type="checkbox" name="" id="pre_DrpNCols" class="inp_check modal_check conf">       <!-- 1st check box NoN -->
+                                <!-- <div class="item_dl type_inline">
+                                    <dt>                                  ============= processor Add Dataset Button =============
+                                        <div class="wrap_check">        seems like there is no button except general page Check it...  
+                                            <input type="checkbox" name="" id="pre_DrpNCols" class="inp_check modal_check conf">       1st check box NoN 
                                             <label for="processor1" class="label_check"><span class="ico_automl ico_check"></span>Drop NaN Columns</label>
                                             <a href="#none" class="tooltip_model"><span class="ico_automl ico_info">자세히보기</span>
                                                 <div class="txt_tooltip">
@@ -384,7 +384,7 @@
                                         <label for="na_col_drop_threshold" class="label_txt">Threshold(%)</label>
                                         <input id="na_col_drop_threshold" type="number" name="" value="0.9" min="0" max="1" step="0.05" class="inp_txt conf">
                                     </dd>
-                                </div>
+                                </div> -->
 
                                 <div class="item_dl type_inline">
                                     <dt>


### PR DESCRIPTION
preprocessor 백엔드에서 더이상 사용하지 않는 기능인 drop nan column을 프론트에서도 삭제하였습니다.